### PR TITLE
Add a geographical README.md file to mm list

### DIFF
--- a/host_vars/README.md
+++ b/host_vars/README.md
@@ -1,6 +1,6 @@
 ## Mirror geographical location
 
-This is a list of the approximate geogrpahical locations for each mirror and a link back to the sponsors main website:
+This is a list of the approximate geographical locations for each mirror and a link back to the sponsor’s main website:
 
   - https://abqix.mm.fcix.net - Albuquerque, New Mexico, USA. - [ABQIX](https://abqix.net)
   - https://ask4.mm.fcix.net

--- a/host_vars/README.md
+++ b/host_vars/README.md
@@ -1,0 +1,35 @@
+## Mirror geographical location
+
+This is a list of the approximate geogrpahical locations for each mirror and a link back to the sponsors main website:
+
+  - https://abqix.mm.fcix.net - Albuquerque, New Mexico, USA. - [ABQIX](https://abqix.net)
+  - https://ask4.mm.fcix.net
+  - https://bungi.mm.fcix.net
+  - https://b4sh.mm.fcix.net - Surrey Hills, England, United Kingdom. - [Broadband for Surrey Hills](https://gigupanddown.net/)
+  - https://codingflyboy.mm.fcix.net
+  - https://coresite.mm.fcix.net
+  - https://creeperhost.mm.fcix.net
+  - https://divergentnetworks.mm.fcix.net - Peterborough, England, United Kingdom. - [Divergent Networks](https://divergentnetworks.co.uk)
+  - https://edgeuno-bog2.mm.fcix.net 
+  - https://forksystems.mm.fcix.net
+  - https://gsl-syd.mm.fcix.net - Sydney, New South Wales, Australia. - [Global Secure Layer](https://globalsecurelayer.com)
+  - https://ima.mm.fcix.net - Montville, Maine, USA. - [Infrastructure Management Associates](https://adisp.net)
+  - https://ix-denver.mm.fcix.net - Denver, Colorado, USA. - [IX-Denver](https://ix-denver.net)
+  - https://lchs.mm.fcix.net - Melbourne, Victoria, Australia. - [Latrobe Community Health Service](https://www.lchs.com.au)
+  - https://level66.mm.fcix.net - Ingelheim am Rhein, Germany. - [Level66.network](https://level66.network)
+  - https://lolhost.mm.fcix.net
+  - https://mnvoip.mm.fcix.net - Bloomington, Minnesota, USA. - [Minnesota VoIP](https://www.mnvoip.com)
+  - https://nnenix.mm.fcix.net - Portland, Maine, USA. - [Northern New England Neutral Internet Exchange](https://www.nnenix.net)
+  - https://nocix.mm.fcix.net - Kansas, Missouri, USA. - [NOCIX](https://www.nocix.net)
+  - https://nullroute.mm.fcix.net - Fremont, California, USA. - [Null Route Networks](https://nullroutenetworks.com)
+  - https://ohioix.mm.fcix.net - Worthington, Ohio, USA. - [Ohio IX](https://ohioix.net)
+  - https://paducahix.mm.fcix.net - Paducah, Kentucky, USA. - [Paducah Internet Exchange](https://paducahix.net)
+  - https://ridgewireless.mm.fcix.net - Cupertino, California, USA. - [Ridge Wireless](https://ridgewireless.net)
+  - https://veronanetworks.mm.fcix.net
+  - https://irltoolkit.mm.fcix.net
+  - https://lesnet.mm.fcix.net - Winnipeg, Manitoba, Canada. - [Les Net](https://les.net)
+  - https://opencolo.mm.fcix.net - Santa Clara, California, USA. - [OpenColo](https://www.opencolo.com)
+  - https://southfront.mm.fcix.net - Albert Lea, Minnesota, USA. - [South Front Networks](https://www.southfront.io)
+  - https://uvermont.mm.fcix.net - Burlington, Vermont, USA. - [The University of Vermont Network Services](https://legacy.drup2.uvm.edu/telcom)
+  - https://volico.mm.fcix.net - Miami, Florida, USA. - [Volico](https://www.volico.com)
+  - https://ziply.mm.fcix.net - Everett, Washington, USA. - [Ziply Fibre](https://ziplyfiber.com)


### PR DESCRIPTION
As per this discussion: https://social.afront.org/@kwf/111722503132136572 this is geographical list of each MM location from what could be garnered through sponsor's websites or peeringDB. Some locations cannot be determined and some that have been documented maybe slightly incorrect.