### PR TITLE
default_qdisc should be fq when tcp_congestion_control is bbr

### DIFF
--- a/files/sysctl.performancetune.conf
+++ b/files/sysctl.performancetune.conf
@@ -1,5 +1,4 @@
-
-net.core.default_qdisc = fq_codel
+net.core.default_qdisc = fq
 net.ipv4.tcp_congestion_control = bbr
 net.core.rmem_max = 134217728
 net.core.wmem_max = 134217728


### PR DESCRIPTION
Source: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/ipv4/Kconfig?h=linux-6.12.y#n667

bbr relies on the rate pacing features of the fq qdisc to work correctly. When the system is configured for fq_codel then bbr tries to perform the rate pacing inside the tcp socket which is more resource intensive and less effective.